### PR TITLE
欲しい物リストからデータ入力画面にデータを渡せるように

### DIFF
--- a/app/src/main/java/com/ze20/saifu/ui/wish/WishFragment.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/wish/WishFragment.kt
@@ -14,6 +14,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.ze20.saifu.AddWishActivity
+import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
 import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.fragment_wish.view.*
@@ -118,6 +119,16 @@ class WishFragment : Fragment() {
                 Toast.makeText(activity, "URLが不正です。", Toast.LENGTH_LONG).show()
                 Log.e("webAccess", exception.toString())
             }
+        }
+        view.shopButton.setOnClickListener {
+            // 購入するボタン
+            val intent = Intent(activity, DataInputActivity::class.java)
+            intent.putExtra("mode", "Wish")
+            intent.putExtra("id", view.idText.text.toString())
+            intent.putExtra("name", view.nameText.text.toString())
+            intent.putExtra("price", price)
+            picture?.let { intent.putExtra("picture", it) }
+            startActivity(intent)
         }
         view.editButton.setOnClickListener {
             // 項目を編集／削除するボタン

--- a/app/src/main/res/layout/activity_add_wish.xml
+++ b/app/src/main/res/layout/activity_add_wish.xml
@@ -42,6 +42,7 @@
                 android:autofillHints=""
                 android:ems="10"
                 android:inputType="textPersonName"
+                android:maxLength="12"
                 android:textColor="@color/colorPrimaryDark" />
         </LinearLayout>
 
@@ -73,6 +74,7 @@
                 android:autofillHints=""
                 android:ems="10"
                 android:inputType="number"
+                android:maxLength="8"
                 android:textColor="@color/colorPrimaryDark" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/activity_data_input.xml
+++ b/app/src/main/res/layout/activity_data_input.xml
@@ -393,6 +393,7 @@
                     android:ems="10"
                     android:hint="@string/memo"
                     android:inputType="textPersonName"
+                    android:maxLength="12"
                     android:singleLine="false"
                     android:textColor="@color/colorPrimaryDark"
                     android:textSize="24sp"


### PR DESCRIPTION
## 概要

欲しい物リストの購入ボタンから
データ入力画面にデータを持ったまま直接推移するようになった

## 関連画像/GIF

![hosiimo3](https://user-images.githubusercontent.com/51361424/89246974-3d701880-d647-11ea-9178-431856ac762f.gif)


## 保留している作業

これで欲しい物リストは完成！（かも）

## 関連課題(Backlog)

bl-4
