### PR TITLE
ショートカットボタン周りの機能を作成

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,6 +9,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="IF_RPAREN_ON_NEW_LINE" value="false" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
@@ -127,9 +128,19 @@
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
       <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+      <option name="KEEP_LINE_BREAKS" value="false" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="CALL_PARAMETERS_WRAP" value="0" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="false" />
+      <option name="METHOD_PARAMETERS_WRAP" value="0" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="false" />
+      <option name="EXTENDS_LIST_WRAP" value="0" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="0" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/app/src/main/java/com/ze20/saifu/AddWishActivity.kt
+++ b/app/src/main/java/com/ze20/saifu/AddWishActivity.kt
@@ -246,7 +246,7 @@ class AddWishActivity : AppCompatActivity() {
                 finish() // 登録できたら画面を閉じる
                 return true
             } catch (exception: Exception) {
-                Toast.makeText(this, "データ登録エラー", Toast.LENGTH_LONG).show()
+                Toast.makeText(this, getString(R.string.recordError), Toast.LENGTH_LONG).show()
                 Log.e("insertData", exception.toString()) // エラーをログに出力
                 busyFlag = false
                 return false
@@ -285,7 +285,7 @@ class AddWishActivity : AppCompatActivity() {
                 finish() // 登録できたら画面を閉じる
                 return true
             } catch (exception: Exception) {
-                Toast.makeText(this, "データ登録エラー", Toast.LENGTH_LONG).show()
+                Toast.makeText(this, getString(R.string.recordError), Toast.LENGTH_LONG).show()
                 Log.e("updateData", exception.toString()) // エラーをログに出力
                 busyFlag = false
                 return false

--- a/app/src/main/java/com/ze20/saifu/ConvenientFunction.kt
+++ b/app/src/main/java/com/ze20/saifu/ConvenientFunction.kt
@@ -3,16 +3,20 @@ package com.ze20.saifu
 import android.app.AlertDialog
 import android.app.Dialog
 import android.content.ClipboardManager
+import android.content.ContentValues
 import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import java.io.ByteArrayOutputStream
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 internal class ConvenientFunction {
 
@@ -43,6 +47,45 @@ internal class ConvenientFunction {
             val manager =
                 appCompatActivity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             manager.hideSoftInputFromWindow(view!!.windowToken, 0)
+        }
+    }
+
+    fun quickInsert(context: Context?, price: Int, name: String = "", category: Int = 0): Boolean {
+        try {
+            val dbHelper = SQLiteDB(context!!, "SaifuDB", null, 1)
+            val database = dbHelper.writableDatabase // 書き込み可能
+
+            // log表
+            // inputDate primary key,payDate,name,price,category,splitCount,picture
+
+            val inputDate = java.util.Date()
+            // INSERTするのに必要なデータをvalueにまとめる
+            val values = ContentValues()
+            values.run {
+                put(
+                    "inputDate",
+                    SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.JAPANESE).format(
+                        inputDate
+                    )
+                )
+                put(
+                    "payDate",
+                    SimpleDateFormat("yyyy-MM-dd 00:00:00", Locale.JAPANESE).format(
+                        inputDate
+                    )
+                )
+                put("name", name)
+                put("price", price)
+                put("category", category)
+                put("splitCount", 1)
+                put("sign", 0)
+            }
+            // DBに登録する できなければエラーを返す
+            database.insertOrThrow("log", null, values)
+            return true
+        } catch (exception: Exception) {
+            Log.e("insertData", exception.toString()) // エラーをログに出力
+            return false
         }
     }
 }

--- a/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
+++ b/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
@@ -481,7 +481,7 @@ open class DataInputActivity : AppCompatActivity() {
             finish() // 登録できたら画面を閉じる
             return true
         } catch (exception: Exception) {
-            Toast.makeText(this, "データ登録エラー", Toast.LENGTH_LONG).show()
+            Toast.makeText(this, getString(R.string.recordError), Toast.LENGTH_LONG).show()
             Log.e("insertData", exception.toString()) // エラーをログに出力
             return false
         }
@@ -511,9 +511,6 @@ open class DataInputActivity : AppCompatActivity() {
                 // shortcut表
                 // id INTEGER primary key,name,price,category
 
-                val inputDate = java.util.Date()
-                // Bitmapに画像があれば取得 なければNull
-                val bmp: Bitmap? = (photoImageView.drawable as BitmapDrawable?)?.bitmap
                 // INSERTするのに必要なデータをvalueにまとめる
                 val values = ContentValues()
                 values.run {
@@ -529,7 +526,7 @@ open class DataInputActivity : AppCompatActivity() {
                 Toast.makeText(this, "すでに登録済みです。", Toast.LENGTH_LONG).show()
             }
         } catch (exception: Exception) {
-            Toast.makeText(this, "データ登録エラー", Toast.LENGTH_LONG).show()
+            Toast.makeText(this, getString(R.string.recordError), Toast.LENGTH_LONG).show()
             Log.e("insertData", exception.toString()) // エラーをログに出力
         }
     }

--- a/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
+++ b/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
@@ -31,9 +31,10 @@ open class DataInputActivity : AppCompatActivity() {
     private var date = java.util.Date() // 今日の日付を格納
     private var sign = false // プラス・マイナス
     private var userSetDate: java.util.Date = java.util.Date() // 設定された日付・初期値は今日
-    private var busyFlag = false // ローディング中はいろいろ動かなくするためのフラグWish
     private var mode = "New" // 現在のモード
     private var id: String? = null // 欲しい物リストのID
+    private var busyFlag = false // ローディング中はいろいろ動かなくするためのフラグ
+    private var addShortcutflag = false
 
     private val fileIntent = Intent(Intent.ACTION_OPEN_DOCUMENT) // ファイルの選択
     private val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE) // カメラ撮影
@@ -262,6 +263,9 @@ open class DataInputActivity : AppCompatActivity() {
         pictureDelete.setOnClickListener {
             deletePicture()
         }
+        shortcutAdd.setOnClickListener {
+            addShortcut()
+        }
     }
 
     private fun modeCheck() {
@@ -483,6 +487,39 @@ open class DataInputActivity : AppCompatActivity() {
             database.delete("wish", whereClauses, whereArgs)
         } catch (exception: Exception) {
             Log.e("deleteData", exception.toString())
+        }
+    }
+
+    private fun addShortcut() {
+        // DBに登録するときに呼び出されます
+
+        try {
+            if (!addShortcutflag) {
+                val dbHelper = SQLiteDB(applicationContext, "SaifuDB", null, 1)
+                val database = dbHelper.writableDatabase // 書き込み可能
+
+                // shortcut表
+                // id INTEGER primary key,name,price,category
+
+                val inputDate = java.util.Date()
+                // Bitmapに画像があれば取得 なければNull
+                val bmp: Bitmap? = (photoImageView.drawable as BitmapDrawable?)?.bitmap
+                // INSERTするのに必要なデータをvalueにまとめる
+                val values = ContentValues()
+                values.run {
+                    put("name", memoEdit.text.toString())
+                    put("price", cFunc.editToInt(moneyEdit))
+                    put("category", 0)
+                }
+                // DBに登録する できなければエラーを返す
+                database.insertOrThrow("shortcut", null, values)
+                Toast.makeText(this, "追加しました。", Toast.LENGTH_LONG).show()
+            } else {
+                Toast.makeText(this, "すでに登録済みです。", Toast.LENGTH_LONG).show()
+            }
+        } catch (exception: Exception) {
+            Toast.makeText(this, "データ登録エラー", Toast.LENGTH_LONG).show()
+            Log.e("insertData", exception.toString()) // エラーをログに出力
         }
     }
 }

--- a/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
+++ b/app/src/main/java/com/ze20/saifu/DataInputActivity.kt
@@ -291,6 +291,16 @@ open class DataInputActivity : AppCompatActivity() {
                     showPicture()
                 }
             }
+            "Shortcut" -> {
+                memoEdit.setText(intent.getStringExtra("name"))
+                // メモがあればメモを表示させる
+                if (memoEdit.text.isNotEmpty()) {
+                    memoAddButton.visibility = View.GONE
+                    memoEdit.visibility = View.VISIBLE
+                }
+                moneyEdit.setText(intent.getIntExtra("price", -1).toString())
+                emsAutoSet()
+            }
         }
     }
 
@@ -513,6 +523,7 @@ open class DataInputActivity : AppCompatActivity() {
                 }
                 // DBに登録する できなければエラーを返す
                 database.insertOrThrow("shortcut", null, values)
+                addShortcutflag = true
                 Toast.makeText(this, "追加しました。", Toast.LENGTH_LONG).show()
             } else {
                 Toast.makeText(this, "すでに登録済みです。", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/ze20/saifu/SQLiteDB.kt
+++ b/app/src/main/java/com/ze20/saifu/SQLiteDB.kt
@@ -33,7 +33,7 @@ class SQLiteDB(
         database?.execSQL("create table if not exists category (id INTEGER primary key AUTOINCREMENT,name,picture)")
         database?.execSQL("create table if not exists notification (id INTEGER primary key AUTOINCREMENT,content,picture)")
         database?.execSQL("create table if not exists budget (id INTEGER primary key AUTOINCREMENT,name,type,price)")
-        database?.execSQL("create table if not exists shortcut (id INTEGER primary key AUTOINCREMENT,name,price)")
+        database?.execSQL("create table if not exists shortcut (id INTEGER primary key AUTOINCREMENT,name,price,category)")
         database?.execSQL("create table if not exists wish (id INTEGER primary key AUTOINCREMENT,name,price,url,picture)")
     }
 

--- a/app/src/main/java/com/ze20/saifu/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/HomeFragment.kt
@@ -11,6 +11,7 @@ import androidx.viewpager.widget.ViewPager
 import com.google.android.material.tabs.TabLayout
 import com.ze20.saifu.NotificationActivity
 import com.ze20.saifu.R
+import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.fragment_home.*
 
 class HomeFragment : Fragment() {
@@ -24,10 +25,20 @@ class HomeFragment : Fragment() {
 
         // スワイプできるフラグメント一覧
         val fragmentList = arrayListOf<Fragment>(
-            sub_fragment1(),
-            sub_fragment2(),
-            sub_fragment3()
+            sub_fragment1()
         )
+
+        val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
+        val database = SQLiteDB.readableDatabase
+        val sql =
+            "select * from shortcut order by 1 asc;"
+        val cursor = database.rawQuery(sql, null)
+        if (cursor.count >= 5) {
+            tablayout.visibility = View.VISIBLE
+            fragmentList.add(sub_fragment2())
+        }
+        if (cursor.count >= 13) fragmentList.add(sub_fragment3())
+        cursor.close()
 
         // レイアウト呼び出し
         val pager =

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
@@ -5,9 +5,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
 import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
+import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.activity_sub_fragment1.view.*
 
 class sub_fragment1 : Fragment() {
@@ -18,9 +20,63 @@ class sub_fragment1 : Fragment() {
     ): View? {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.activity_sub_fragment1, container, false)
-        view.input_button.setOnClickListener() {
-            startActivity(Intent(getActivity(), DataInputActivity::class.java))
+        view.input_button.setOnClickListener {
+            startActivity(Intent(activity, DataInputActivity::class.java))
         }
+        val shortcut: ArrayList<Button> =
+            arrayListOf(
+                view.shurtcut_button1,
+                view.shurtcut_button2,
+                view.shurtcut_button3,
+                view.shurtcut_button4
+            )
+        val nameal: ArrayList<String> = arrayListOf()
+        val priceal: ArrayList<Int> = arrayListOf()
+        val categoryal: ArrayList<Int> = arrayListOf()
+        val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
+        val database = SQLiteDB.readableDatabase
+        val sql =
+            "select * from shortcut order by 1 asc limit 4;"
+        val cursor = database.rawQuery(sql, null)
+
+        var i = 0
+        if (cursor.count > 0) {
+            cursor.moveToFirst()
+            while (!cursor.isAfterLast) {
+                if (cursor.getString(1) == "") {
+                    shortcut[i].text = getString(
+                        R.string.currencyString, "%,d".format(cursor.getInt(2))
+                    )
+                    shortcut[i].setTextSize(30.0f)
+                } else {
+                    shortcut[i].text = getString(
+                        R.string.shortcutformat,
+                        cursor.getString(1),
+                        "%,d".format(cursor.getInt(2))
+                    )
+                }
+                nameal.add(cursor.getString(1))
+                priceal.add(cursor.getInt(2))
+                categoryal.add(cursor.getInt(3))
+                shortcut[i].tag = i
+                shortcut[i].visibility = View.VISIBLE
+                shortcut[i].setOnClickListener {
+                    val intent = Intent(activity, DataInputActivity::class.java)
+                    val tag = it.tag as Int
+                    intent.putExtra("mode", "Shortcut")
+                    intent.putExtra("name", nameal[tag])
+                    intent.putExtra("price", priceal[tag])
+                    intent.putExtra("category", categoryal[tag])
+                    startActivity(intent)
+                }
+                i++
+                cursor.moveToNext()
+            }
+        } else {
+            view.button4Layout.visibility = View.GONE
+        }
+        cursor.close()
+
         return view
     }
 }

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
@@ -6,7 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import com.ze20.saifu.ConvenientFunction
 import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
 import com.ze20.saifu.SQLiteDB
@@ -61,13 +64,40 @@ class sub_fragment1 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val intent = Intent(activity, DataInputActivity::class.java)
-                    val tag = it.tag as Int
-                    intent.putExtra("mode", "Shortcut")
-                    intent.putExtra("name", nameal[tag])
-                    intent.putExtra("price", priceal[tag])
-                    intent.putExtra("category", categoryal[tag])
-                    startActivity(intent)
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
+                        val tag = it.tag as Int
+                        it.isEnabled = false
+                        if (ConvenientFunction().quickInsert(
+                                context,
+                                priceal[tag],
+                                nameal[tag],
+                                categoryal[tag]
+                            )
+                        ) {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordFinish),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        } else {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordError),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        }
+                    } else {
+                        val intent = Intent(activity, DataInputActivity::class.java)
+                        val tag = it.tag as Int
+                        intent.putExtra("mode", "Shortcut")
+                        intent.putExtra("name", nameal[tag])
+                        intent.putExtra("price", priceal[tag])
+                        intent.putExtra("category", categoryal[tag])
+                        startActivity(intent)
+                    }
                 }
                 i++
                 cursor.moveToNext()

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment1.kt
@@ -16,30 +16,20 @@ import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.activity_sub_fragment1.view.*
 
 class sub_fragment1 : Fragment() {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.activity_sub_fragment1, container, false)
         view.input_button.setOnClickListener {
             startActivity(Intent(activity, DataInputActivity::class.java))
         }
         val shortcut: ArrayList<Button> =
-            arrayListOf(
-                view.shurtcut_button1,
-                view.shurtcut_button2,
-                view.shurtcut_button3,
-                view.shurtcut_button4
-            )
+            arrayListOf(view.shurtcut_button1, view.shurtcut_button2, view.shurtcut_button3, view.shurtcut_button4)
         val nameal: ArrayList<String> = arrayListOf()
         val priceal: ArrayList<Int> = arrayListOf()
         val categoryal: ArrayList<Int> = arrayListOf()
         val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
         val database = SQLiteDB.readableDatabase
-        val sql =
-            "select * from shortcut order by 1 asc limit 4;"
+        val sql = "select * from shortcut order by 1 asc limit 4;"
         val cursor = database.rawQuery(sql, null)
 
         var i = 0
@@ -47,16 +37,12 @@ class sub_fragment1 : Fragment() {
             cursor.moveToFirst()
             while (!cursor.isAfterLast) {
                 if (cursor.getString(1) == "") {
-                    shortcut[i].text = getString(
-                        R.string.currencyString, "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.currencyString, "%,d".format(cursor.getInt(2)))
                     shortcut[i].setTextSize(30.0f)
                 } else {
-                    shortcut[i].text = getString(
-                        R.string.shortcutformat,
-                        cursor.getString(1),
-                        "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.shortcutformat, cursor.getString(1), "%,d".format(cursor.getInt(2)))
                 }
                 nameal.add(cursor.getString(1))
                 priceal.add(cursor.getInt(2))
@@ -64,29 +50,15 @@ class sub_fragment1 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity)
                     if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
                         val tag = it.tag as Int
                         it.isEnabled = false
-                        if (ConvenientFunction().quickInsert(
-                                context,
-                                priceal[tag],
-                                nameal[tag],
-                                categoryal[tag]
-                            )
-                        ) {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordFinish),
-                                Toast.LENGTH_LONG
-                            ).show()
+                        if (ConvenientFunction().quickInsert(context, priceal[tag], nameal[tag], categoryal[tag])) {
+                            Toast.makeText(activity, getString(R.string.recordFinish), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         } else {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordError),
-                                Toast.LENGTH_LONG
-                            ).show()
+                            Toast.makeText(activity, getString(R.string.recordError), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         }
                     } else {

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
@@ -1,11 +1,16 @@
 package com.ze20.saifu.ui.home
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
+import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
+import com.ze20.saifu.SQLiteDB
+import kotlinx.android.synthetic.main.activity_sub_fragment2.view.*
 
 class sub_fragment2 : Fragment() {
     override fun onCreateView(
@@ -13,7 +18,62 @@ class sub_fragment2 : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.activity_sub_fragment2, container, false)
+        val view = inflater.inflate(R.layout.activity_sub_fragment2, container, false)
+        val shortcut: ArrayList<Button> =
+            arrayListOf(
+                view.shurtcut_button5,
+                view.shurtcut_button6,
+                view.shurtcut_button7,
+                view.shurtcut_button8,
+                view.shurtcut_button9,
+                view.shurtcut_button10,
+                view.shurtcut_button11,
+                view.shurtcut_button12
+            )
+        val nameal: ArrayList<String> = arrayListOf()
+        val priceal: ArrayList<Int> = arrayListOf()
+        val categoryal: ArrayList<Int> = arrayListOf()
+        val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
+        val database = SQLiteDB.readableDatabase
+        val sql =
+            "select * from shortcut order by 1 asc limit 8 offset 4;"
+        val cursor = database.rawQuery(sql, null)
+
+        var i = 0
+        if (cursor.count > 0) {
+            cursor.moveToFirst()
+            while (!cursor.isAfterLast) {
+                if (cursor.getString(1) == "") {
+                    shortcut[i].text = getString(
+                        R.string.currencyString, "%,d".format(cursor.getInt(2))
+                    )
+                    shortcut[i].setTextSize(30.0f)
+                } else {
+                    shortcut[i].text = getString(
+                        R.string.shortcutformat,
+                        cursor.getString(1),
+                        "%,d".format(cursor.getInt(2))
+                    )
+                }
+                nameal.add(cursor.getString(1))
+                priceal.add(cursor.getInt(2))
+                categoryal.add(cursor.getInt(3))
+                shortcut[i].tag = i
+                shortcut[i].visibility = View.VISIBLE
+                shortcut[i].setOnClickListener {
+                    val intent = Intent(activity, DataInputActivity::class.java)
+                    val tag = it.tag as Int
+                    intent.putExtra("mode", "Shortcut")
+                    intent.putExtra("name", nameal[tag])
+                    intent.putExtra("price", priceal[tag])
+                    intent.putExtra("category", categoryal[tag])
+                    startActivity(intent)
+                }
+                i++
+                cursor.moveToNext()
+            }
+        }
+        cursor.close()
+        return view
     }
 }

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
@@ -16,30 +16,16 @@ import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.activity_sub_fragment2.view.*
 
 class sub_fragment2 : Fragment() {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.activity_sub_fragment2, container, false)
         val shortcut: ArrayList<Button> =
-            arrayListOf(
-                view.shurtcut_button5,
-                view.shurtcut_button6,
-                view.shurtcut_button7,
-                view.shurtcut_button8,
-                view.shurtcut_button9,
-                view.shurtcut_button10,
-                view.shurtcut_button11,
-                view.shurtcut_button12
-            )
+            arrayListOf(view.shurtcut_button5, view.shurtcut_button6, view.shurtcut_button7, view.shurtcut_button8, view.shurtcut_button9, view.shurtcut_button10, view.shurtcut_button11, view.shurtcut_button12)
         val nameal: ArrayList<String> = arrayListOf()
         val priceal: ArrayList<Int> = arrayListOf()
         val categoryal: ArrayList<Int> = arrayListOf()
         val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
         val database = SQLiteDB.readableDatabase
-        val sql =
-            "select * from shortcut order by 1 asc limit 8 offset 4;"
+        val sql = "select * from shortcut order by 1 asc limit 8 offset 4;"
         val cursor = database.rawQuery(sql, null)
 
         var i = 0
@@ -47,16 +33,12 @@ class sub_fragment2 : Fragment() {
             cursor.moveToFirst()
             while (!cursor.isAfterLast) {
                 if (cursor.getString(1) == "") {
-                    shortcut[i].text = getString(
-                        R.string.currencyString, "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.currencyString, "%,d".format(cursor.getInt(2)))
                     shortcut[i].setTextSize(30.0f)
                 } else {
-                    shortcut[i].text = getString(
-                        R.string.shortcutformat,
-                        cursor.getString(1),
-                        "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.shortcutformat, cursor.getString(1), "%,d".format(cursor.getInt(2)))
                 }
                 nameal.add(cursor.getString(1))
                 priceal.add(cursor.getInt(2))
@@ -64,29 +46,15 @@ class sub_fragment2 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity)
                     if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
                         val tag = it.tag as Int
                         it.isEnabled = false
-                        if (ConvenientFunction().quickInsert(
-                                context,
-                                priceal[tag],
-                                nameal[tag],
-                                categoryal[tag]
-                            )
-                        ) {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordFinish),
-                                Toast.LENGTH_LONG
-                            ).show()
+                        if (ConvenientFunction().quickInsert(context, priceal[tag], nameal[tag], categoryal[tag])) {
+                            Toast.makeText(activity, getString(R.string.recordFinish), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         } else {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordError),
-                                Toast.LENGTH_LONG
-                            ).show()
+                            Toast.makeText(activity, getString(R.string.recordError), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         }
                     } else {

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment2.kt
@@ -6,7 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import com.ze20.saifu.ConvenientFunction
 import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
 import com.ze20.saifu.SQLiteDB
@@ -61,13 +64,40 @@ class sub_fragment2 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val intent = Intent(activity, DataInputActivity::class.java)
-                    val tag = it.tag as Int
-                    intent.putExtra("mode", "Shortcut")
-                    intent.putExtra("name", nameal[tag])
-                    intent.putExtra("price", priceal[tag])
-                    intent.putExtra("category", categoryal[tag])
-                    startActivity(intent)
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
+                        val tag = it.tag as Int
+                        it.isEnabled = false
+                        if (ConvenientFunction().quickInsert(
+                                context,
+                                priceal[tag],
+                                nameal[tag],
+                                categoryal[tag]
+                            )
+                        ) {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordFinish),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        } else {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordError),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        }
+                    } else {
+                        val intent = Intent(activity, DataInputActivity::class.java)
+                        val tag = it.tag as Int
+                        intent.putExtra("mode", "Shortcut")
+                        intent.putExtra("name", nameal[tag])
+                        intent.putExtra("price", priceal[tag])
+                        intent.putExtra("category", categoryal[tag])
+                        startActivity(intent)
+                    }
                 }
                 i++
                 cursor.moveToNext()

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
@@ -16,30 +16,16 @@ import com.ze20.saifu.SQLiteDB
 import kotlinx.android.synthetic.main.activity_sub_fragment3.view.*
 
 class sub_fragment3 : Fragment() {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.activity_sub_fragment3, container, false)
         val shortcut: ArrayList<Button> =
-            arrayListOf(
-                view.shurtcut_button13,
-                view.shurtcut_button14,
-                view.shurtcut_button15,
-                view.shurtcut_button16,
-                view.shurtcut_button17,
-                view.shurtcut_button18,
-                view.shurtcut_button19,
-                view.shurtcut_button20
-            )
+            arrayListOf(view.shurtcut_button13, view.shurtcut_button14, view.shurtcut_button15, view.shurtcut_button16, view.shurtcut_button17, view.shurtcut_button18, view.shurtcut_button19, view.shurtcut_button20)
         val nameal: ArrayList<String> = arrayListOf()
         val priceal: ArrayList<Int> = arrayListOf()
         val categoryal: ArrayList<Int> = arrayListOf()
         val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
         val database = SQLiteDB.readableDatabase
-        val sql =
-            "select * from shortcut order by 1 asc limit 8 offset 12;"
+        val sql = "select * from shortcut order by 1 asc limit 8 offset 12;"
         val cursor = database.rawQuery(sql, null)
 
         var i = 0
@@ -47,16 +33,12 @@ class sub_fragment3 : Fragment() {
             cursor.moveToFirst()
             while (!cursor.isAfterLast) {
                 if (cursor.getString(1) == "") {
-                    shortcut[i].text = getString(
-                        R.string.currencyString, "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.currencyString, "%,d".format(cursor.getInt(2)))
                     shortcut[i].setTextSize(30.0f)
                 } else {
-                    shortcut[i].text = getString(
-                        R.string.shortcutformat,
-                        cursor.getString(1),
-                        "%,d".format(cursor.getInt(2))
-                    )
+                    shortcut[i].text =
+                        getString(R.string.shortcutformat, cursor.getString(1), "%,d".format(cursor.getInt(2)))
                 }
                 nameal.add(cursor.getString(1))
                 priceal.add(cursor.getInt(2))
@@ -64,29 +46,15 @@ class sub_fragment3 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity)
                     if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
                         val tag = it.tag as Int
                         it.isEnabled = false
-                        if (ConvenientFunction().quickInsert(
-                                context,
-                                priceal[tag],
-                                nameal[tag],
-                                categoryal[tag]
-                            )
-                        ) {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordFinish),
-                                Toast.LENGTH_LONG
-                            ).show()
+                        if (ConvenientFunction().quickInsert(context, priceal[tag], nameal[tag], categoryal[tag])) {
+                            Toast.makeText(activity, getString(R.string.recordFinish), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         } else {
-                            Toast.makeText(
-                                activity,
-                                getString(R.string.recordError),
-                                Toast.LENGTH_LONG
-                            ).show()
+                            Toast.makeText(activity, getString(R.string.recordError), Toast.LENGTH_LONG).show()
                             it.isEnabled = true
                         }
                     } else {

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
@@ -6,7 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import com.ze20.saifu.ConvenientFunction
 import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
 import com.ze20.saifu.SQLiteDB
@@ -61,13 +64,40 @@ class sub_fragment3 : Fragment() {
                 shortcut[i].tag = i
                 shortcut[i].visibility = View.VISIBLE
                 shortcut[i].setOnClickListener {
-                    val intent = Intent(activity, DataInputActivity::class.java)
-                    val tag = it.tag as Int
-                    intent.putExtra("mode", "Shortcut")
-                    intent.putExtra("name", nameal[tag])
-                    intent.putExtra("price", priceal[tag])
-                    intent.putExtra("category", categoryal[tag])
-                    startActivity(intent)
+                    val sharedPref = PreferenceManager.getDefaultSharedPreferences(activity);
+                    if (sharedPref.getBoolean("shortCutQuickAdd", false)) {
+                        val tag = it.tag as Int
+                        it.isEnabled = false
+                        if (ConvenientFunction().quickInsert(
+                                context,
+                                priceal[tag],
+                                nameal[tag],
+                                categoryal[tag]
+                            )
+                        ) {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordFinish),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        } else {
+                            Toast.makeText(
+                                activity,
+                                getString(R.string.recordError),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            it.isEnabled = true
+                        }
+                    } else {
+                        val intent = Intent(activity, DataInputActivity::class.java)
+                        val tag = it.tag as Int
+                        intent.putExtra("mode", "Shortcut")
+                        intent.putExtra("name", nameal[tag])
+                        intent.putExtra("price", priceal[tag])
+                        intent.putExtra("category", categoryal[tag])
+                        startActivity(intent)
+                    }
                 }
                 i++
                 cursor.moveToNext()

--- a/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
+++ b/app/src/main/java/com/ze20/saifu/ui/home/sub_fragment3.kt
@@ -1,11 +1,16 @@
 package com.ze20.saifu.ui.home
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
+import com.ze20.saifu.DataInputActivity
 import com.ze20.saifu.R
+import com.ze20.saifu.SQLiteDB
+import kotlinx.android.synthetic.main.activity_sub_fragment3.view.*
 
 class sub_fragment3 : Fragment() {
     override fun onCreateView(
@@ -13,7 +18,62 @@ class sub_fragment3 : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.activity_sub_fragment3, container, false)
+        val view = inflater.inflate(R.layout.activity_sub_fragment3, container, false)
+        val shortcut: ArrayList<Button> =
+            arrayListOf(
+                view.shurtcut_button13,
+                view.shurtcut_button14,
+                view.shurtcut_button15,
+                view.shurtcut_button16,
+                view.shurtcut_button17,
+                view.shurtcut_button18,
+                view.shurtcut_button19,
+                view.shurtcut_button20
+            )
+        val nameal: ArrayList<String> = arrayListOf()
+        val priceal: ArrayList<Int> = arrayListOf()
+        val categoryal: ArrayList<Int> = arrayListOf()
+        val SQLiteDB = SQLiteDB(requireContext(), "SaifuDB", null, 1)
+        val database = SQLiteDB.readableDatabase
+        val sql =
+            "select * from shortcut order by 1 asc limit 8 offset 12;"
+        val cursor = database.rawQuery(sql, null)
+
+        var i = 0
+        if (cursor.count > 0) {
+            cursor.moveToFirst()
+            while (!cursor.isAfterLast) {
+                if (cursor.getString(1) == "") {
+                    shortcut[i].text = getString(
+                        R.string.currencyString, "%,d".format(cursor.getInt(2))
+                    )
+                    shortcut[i].setTextSize(30.0f)
+                } else {
+                    shortcut[i].text = getString(
+                        R.string.shortcutformat,
+                        cursor.getString(1),
+                        "%,d".format(cursor.getInt(2))
+                    )
+                }
+                nameal.add(cursor.getString(1))
+                priceal.add(cursor.getInt(2))
+                categoryal.add(cursor.getInt(3))
+                shortcut[i].tag = i
+                shortcut[i].visibility = View.VISIBLE
+                shortcut[i].setOnClickListener {
+                    val intent = Intent(activity, DataInputActivity::class.java)
+                    val tag = it.tag as Int
+                    intent.putExtra("mode", "Shortcut")
+                    intent.putExtra("name", nameal[tag])
+                    intent.putExtra("price", priceal[tag])
+                    intent.putExtra("category", categoryal[tag])
+                    startActivity(intent)
+                }
+                i++
+                cursor.moveToNext()
+            }
+        }
+        cursor.close()
+        return view
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_double_arrow_48.xml
+++ b/app/src/main/res/drawable/ic_baseline_double_arrow_48.xml
@@ -1,0 +1,13 @@
+<vector android:height="48dp"
+    android:tint="#707070"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="48dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,5l-4.5,0l5,7l-5,7l4.5,0l5,-7z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8.5,5l-4.5,0l5,7l-5,7l4.5,0l5,-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_edit_128.xml
+++ b/app/src/main/res/drawable/ic_baseline_edit_128.xml
@@ -1,0 +1,10 @@
+<vector android:height="128dp"
+    android:tint="#707070"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="128dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_edit_48.xml
+++ b/app/src/main/res/drawable/ic_baseline_edit_48.xml
@@ -1,0 +1,10 @@
+<vector android:height="48dp"
+    android:tint="#707070"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="48dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/layout/activity_sub_fragment1.xml
+++ b/app/src/main/res/layout/activity_sub_fragment1.xml
@@ -20,15 +20,19 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/input_button"
-            android:text="Button" />
+            android:foreground="@drawable/ic_baseline_edit_128"
+            android:foregroundGravity="center"
+            android:foregroundTintMode="src_in" />
 
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/button4Layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:visibility="visible">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -43,7 +47,9 @@
                 android:layout_margin="8sp"
                 android:layout_weight="1"
                 android:background="@drawable/shurtcut_button"
-                android:text="Button" />
+                android:text="Button"
+                android:textSize="18sp"
+                android:visibility="invisible" />
 
             <Button
                 android:id="@+id/shurtcut_button2"
@@ -52,7 +58,9 @@
                 android:layout_margin="8sp"
                 android:layout_weight="1"
                 android:background="@drawable/shurtcut_button"
-                android:text="Button" />
+                android:text="Button"
+                android:textSize="18sp"
+                android:visibility="invisible" />
         </LinearLayout>
 
         <LinearLayout
@@ -68,7 +76,9 @@
                 android:layout_margin="8sp"
                 android:layout_weight="1"
                 android:background="@drawable/shurtcut_button"
-                android:text="Button" />
+                android:text="Button"
+                android:textSize="18sp"
+                android:visibility="invisible" />
 
             <Button
                 android:id="@+id/shurtcut_button4"
@@ -77,7 +87,9 @@
                 android:layout_margin="8sp"
                 android:layout_weight="1"
                 android:background="@drawable/shurtcut_button"
-                android:text="Button" />
+                android:text="Button"
+                android:textSize="18sp"
+                android:visibility="invisible" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_sub_fragment2.xml
+++ b/app/src/main/res/layout/activity_sub_fragment2.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -20,7 +19,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button6"
@@ -29,7 +30,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -45,7 +48,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button8"
@@ -54,7 +59,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -70,7 +77,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button10"
@@ -79,7 +88,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -95,7 +106,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button12"
@@ -104,6 +117,8 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_sub_fragment3.xml
+++ b/app/src/main/res/layout/activity_sub_fragment3.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -20,7 +19,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button14"
@@ -29,7 +30,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -45,7 +48,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button16"
@@ -54,7 +59,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -70,7 +77,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button18"
@@ -79,7 +88,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
     <LinearLayout
@@ -95,7 +106,9 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
 
         <Button
             android:id="@+id/shurtcut_button20"
@@ -104,6 +117,8 @@
             android:layout_margin="8sp"
             android:layout_weight="1"
             android:background="@drawable/shurtcut_button"
-            android:text="Button" />
+            android:text="Button"
+            android:textSize="18sp"
+            android:visibility="invisible" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -11,94 +11,101 @@
         android:id="@+id/notificationButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/NC_transition"
         android:src="@drawable/ic_notifications_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.041"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:contentDescription="@string/NC_transition"
 
         app:layout_constraintVertical_bias="0.022" />
 
     <LinearLayout
-        android:id="@+id/linearLayout8"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout9"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0">
-
-        <TextView
-            android:id="@+id/today"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:gravity="center"
-            android:text="今日の日付"
-            android:textColor="@color/blackColor"
-            android:textSize="20dp"
-            tools:ignore="MissingConstraints" />
-
-        <TextView
-            android:id="@+id/money"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="今月使える金額"
-            android:textColor="@color/colorPrimary"
-            android:textSize="36dp"
-            tools:ignore="MissingConstraints" />
-
-        <TextView
-            android:id="@+id/limit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="16dp"
-            android:gravity="right"
-            android:text="使える上限"
-            android:textColor="@color/colorPrimary"
-            android:textSize="20dp" />
-
-        <ProgressBar
-            android:id="@+id/progressBar"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:layout_margin="16dp" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/linearLayout9"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginStart="9dp"
-        android:layout_marginEnd="9dp"
-        android:layout_marginBottom="64dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <!--スワイプで切り替える部分-->
+        <LinearLayout
+            android:id="@+id/linearLayout8"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-        <androidx.viewpager.widget.ViewPager
-            android:id="@+id/pager"
+            <TextView
+                android:id="@+id/today"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center"
+                android:text="今日の日付"
+                android:textColor="@color/blackColor"
+                android:textSize="20dp"
+                tools:ignore="MissingConstraints" />
+
+            <TextView
+                android:id="@+id/money"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="今月使える金額"
+                android:textColor="@color/colorPrimary"
+                android:textSize="36dp"
+                tools:ignore="MissingConstraints" />
+
+            <TextView
+                android:id="@+id/limit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="16dp"
+                android:gravity="right"
+                android:text="使える上限"
+                android:textColor="@color/colorPrimary"
+                android:textSize="20dp" />
+
+            <ProgressBar
+                android:id="@+id/progressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_margin="16dp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linearLayout9"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1" />
+            android:layout_marginStart="9dp"
+            android:layout_marginEnd="9dp"
+            android:layout_marginBottom="64dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tablayout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="12"
-            app:tabBackground="@drawable/tab_selector"
-            app:tabGravity="center"
-            app:tabIndicatorHeight="0dp" />
+            <!--スワイプで切り替える部分-->
+
+            <androidx.viewpager.widget.ViewPager
+                android:id="@+id/pager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/tablayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="12"
+                android:visibility="gone"
+                app:tabBackground="@drawable/tab_selector"
+                app:tabGravity="center"
+                app:tabIndicatorHeight="0dp" />
+        </LinearLayout>
     </LinearLayout>
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,6 @@
     <string name="shortcutQuickAdd">ショートカット即時登録</string>
     <string name="shortcutEdit">ショートカット編集</string>
     <string name="shortcutformat">%1$s\n¥%2$s</string>
+    <string name="recordFinish">記録完了</string>
+    <string name="recordError">データ登録エラー</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="NC_transition">NC_transition</string>
     <string name="shortcutQuickAdd">ショートカット即時登録</string>
     <string name="shortcutEdit">ショートカット編集</string>
+    <string name="shortcutformat">%1$s\n¥%2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,6 @@
     <string name="amazonAdd">アマゾンから追加</string>
     <string name="delete_item">項目を削除</string>
     <string name="NC_transition">NC_transition</string>
+    <string name="shortcutQuickAdd">ショートカット即時登録</string>
+    <string name="shortcutEdit">ショートカット編集</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -22,7 +22,14 @@
         android:icon="@drawable/ic_baseline_folder_48"
         app:key="category"
         app:title="@string/category_config" />
-
+    <SwitchPreferenceCompat
+        android:icon="@drawable/ic_baseline_double_arrow_48"
+        app:key="shortCutQuickAdd"
+        app:title="@string/shortcutQuickAdd" />
+    <Preference
+        android:icon="@drawable/ic_baseline_edit_48"
+        app:key="shortCutEdit"
+        app:title="@string/shortcutEdit" />
 
 
 </PreferenceScreen>


### PR DESCRIPTION
## 概要

**設定項目を追加 & データベース項目を追加**
* ショートカットに関する設定「ショートカット即時登録」と「ショートカット設定」を追加しました。
* ショートカット表にカテゴリを保存するように変更しました。

**ショートカットを追加するボタンを実装**
* データ入力画面の一番下にあったボタンが使えるようになりました。
* 1回の入力に付き1回しか登録できません。

**ショートカットボタンを動作するようにして出たり消えたりするようにした**
* ショートカットボタンを使うとそのデータが入力された状態でデータ入力画面が開くようになりました。
* 登録されていない項目はボタンが表示されないようになりました。
* 4項目以下や12項目以下でページ数が減るようになりました。
* 4項目以下でページ数が1の場合・が表示されなくなりました。
* 0項目の場合、登録ボタンが大きくなるようになりました。
* 名前が入力されていない場合、金額が大きく表示されるようになりました。

**ショートカット押下で即時登録モードを実装**
* 設定項目の「ショートカット即時登録」をオンにすると、データ入力画面を開かずにそのまま登録されます。
* データ登録エラーの文字列などをStringsに入れました。

## 保留している作業

設定項目の「ショートカット編集」

## レビュアーへ

コミット毎に見たほうが見やすいかもしれません。 （Commitsから見れます）