### PR TITLE
とりあえず実装予定が遅いボタンを非表示に

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -13,12 +13,13 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/NC_transition"
         android:src="@drawable/ic_notifications_black_24dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.041"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
 
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.022" />
 
     <LinearLayout

--- a/app/src/main/res/menu/menu_log.xml
+++ b/app/src/main/res/menu/menu_log.xml
@@ -4,15 +4,18 @@
 
    <item
        android:id="@+id/graph"
-       android:title="@string/graph" />
+       android:title="@string/graph"
+       android:visible="false" />
    <item
        android:id="@+id/report"
-       android:title="@string/report" />
+       android:title="@string/report"
+       android:visible="false" />
 
    <item
        android:id="@+id/search_view"
        android:icon="@drawable/ic_baseline_search_24"
        android:title="@string/search"
+       android:visible="false"
        app:showAsAction="always" />
 
 </menu>


### PR DESCRIPTION
<!-- いらない項目は消去してもらって構いません 説明はコメントなので残しておいていいです -->

## 概要

ログ画面のグラフ／レポート／検索
メイン画面の通知リスト

とりあえず非表示にしました。
また実装した時に表示にしてください。

